### PR TITLE
Use regex instead of regular replace

### DIFF
--- a/Week-4/italianSyllabificationSolution.py
+++ b/Week-4/italianSyllabificationSolution.py
@@ -42,7 +42,7 @@ vowels = ["a", "e", "i", "o", "u", "à", "è", "ì", "ò", "ù", "ï", "é", "ó
 
 # First: clean up our string, save it to a list:
 
-testList = inferno.lower().replace(",", "").replace("’", "").replace('"', "").replace("!", "").replace(".", "").replace(":", "").replace(";", "").split()
+testList = re.sub("([^\w\s])","",inferno.lower()).split();
 
 
 #print(testList)


### PR DESCRIPTION
Instead of using a load of replace(), would it not be a better idea to use regex instead though? Since regex was imported but was never used at all in the project. Plus the code is shorter and easier to read.